### PR TITLE
Use the duration_in_traffic instead of duration

### DIFF
--- a/src/traffic-status.coffee
+++ b/src/traffic-status.coffee
@@ -36,7 +36,7 @@ module.exports = (robot) ->
 			@userbrain.mode = default_travel_mode
 		if @userbrain.home and @userbrain.work
 			msg.http("https://maps.googleapis.com/maps/api/distancematrix/json")
-				.query({origins: "#{@userbrain.work}", destinations: "#{@userbrain.home}", mode: "#{@userbrain.mode}", departure_time: "now", key: api_key}, traffic_model: "best_guess")
+				.query({origins: "#{@userbrain.work}", destinations: "#{@userbrain.home}", mode: "#{@userbrain.mode}", departure_time: "now", key: api_key})
 				.header('Accept', 'application/json')
 				.get() (err, res, body) ->
 					if err

--- a/src/traffic-status.coffee
+++ b/src/traffic-status.coffee
@@ -36,7 +36,7 @@ module.exports = (robot) ->
 			@userbrain.mode = default_travel_mode
 		if @userbrain.home and @userbrain.work
 			msg.http("https://maps.googleapis.com/maps/api/distancematrix/json")
-				.query({origins: "#{@userbrain.work}", destinations: "#{@userbrain.home}", mode: "#{@userbrain.mode}", departure_time: "now", key: api_key})
+				.query({origins: "#{@userbrain.work}", destinations: "#{@userbrain.home}", mode: "#{@userbrain.mode}", departure_time: "now", key: api_key}, traffic_model: "best_guess")
 				.header('Accept', 'application/json')
 				.get() (err, res, body) ->
 					if err

--- a/src/traffic-status.coffee
+++ b/src/traffic-status.coffee
@@ -45,7 +45,8 @@ module.exports = (robot) ->
 					data = JSON.parse body
 					if data.error_message
 						msg.send "Error: #{data.error_message}"
-					msg.send "From #{data.origin_addresses[0]} to #{data.destination_addresses[0]}, it will take #{data.rows[0].elements[0].duration.text}"
+					duration = if data.rows[0].elements[0].duration_in_traffic then data.rows[0].elements[0].duration_in_traffic.text else data.rows[0].elements[0].duration.text
+					msg.send "From #{data.origin_addresses[0]} to #{data.destination_addresses[0]}, it will take #{duration}"
 					return
 		else
 			msg.send "You need to set your home and work address in my brain, #{msg.message.user.name}"


### PR DESCRIPTION
Hi,

The API gives us the possibility to have an estimation of the travel time in traffic with the `duration_in_traffic` response parameter.

It would be great to use it when available in the response, it could result in more accurate time estimation. Unfortunately it is not possible to use it with an `arrival_time`, so it would be used only for the _i wanna go home_ which use a `departure_time`.
